### PR TITLE
Refactor datepick value

### DIFF
--- a/designSystem/atoms/Calendar.tsx
+++ b/designSystem/atoms/Calendar.tsx
@@ -31,15 +31,18 @@ import {
 } from "date-fns"
 
 export type CalendarProps = {
+  name: string
   startYearRange: number // Range determines the years used by the Select in the calendar
   endYearRange: number
   defaultDate?: Date
+
 }
 
 type CalendarStateProps = {
   selectedDay: Date
   setSelectedDay: (value: Date) => void
   setShowCalendar: (value: "CalendarClosed" | "CalendarOpen") => void
+  handleSelectedDayChange: (name: string, selectedDay: Date) => void
 }
 
 const Calendar: FC<CalendarProps & CalendarStateProps> = ({
@@ -196,11 +199,7 @@ const Calendar: FC<CalendarProps & CalendarStateProps> = ({
                   >
                     <button
                       type="button"
-                      onClick={() => {
-                        setSelectedDay(day)
-                        handleSelectedDayChange(name, day)
-                        setShowCalendar("CalendarClosed") // Remove if don't want calendar to close after selecting a day
-                      }} // when user clicks on a day, set that day as the selected day
+                      onClick={() => { handleSelectedDayChange(name, day) }} // when user clicks on a day, update the state and input in DatePick with the selected day
                       className={classNames(
                         // current day selected?
                         isEqual(day, selectedDay) && "text-white",

--- a/designSystem/atoms/Calendar.tsx
+++ b/designSystem/atoms/Calendar.tsx
@@ -49,6 +49,8 @@ const Calendar: FC<CalendarProps & CalendarStateProps> = ({
   defaultDate,
   selectedDay,
   setSelectedDay,
+  handleSelectedDayChange,
+  name
 }) => {
   let today = startOfToday() // a date-fns function that gets current date on user's machine
   // let [selectedDay, setSelectedDay] = useState(today) // the day currently selected by user
@@ -196,6 +198,7 @@ const Calendar: FC<CalendarProps & CalendarStateProps> = ({
                       type="button"
                       onClick={() => {
                         setSelectedDay(day)
+                        handleSelectedDayChange(name, day)
                         setShowCalendar("CalendarClosed") // Remove if don't want calendar to close after selecting a day
                       }} // when user clicks on a day, set that day as the selected day
                       className={classNames(

--- a/designSystem/molecules/DatePick.tsx
+++ b/designSystem/molecules/DatePick.tsx
@@ -10,9 +10,9 @@ import Calendar, { CalendarProps } from "@designSystem/atoms/Calendar"
 import { useForm } from "react-hook-form"
 
 export type DatePickProps = {
-  name: string
+  name?: string // Optional because wrapper Field component will require and pass it in
   label?: string | null
-  value: string | number
+  value?: string | number
   tipText?: string | null
   defaultDate?: string | Date // should add a type guard function to validate format in future
 }
@@ -50,10 +50,11 @@ const DatePick: FC<DatePickProps & CalendarProps & InputProps> = forwardRef<HTML
 
     // ------------- Used to sync Calendar selection with the DatePick input's value -------------
     const { setValue } = useForm() // used by Calendar component to set the value of the input field
-    const handleSelectedDayChange = (name: string, selectedDay: number | Date ) => {
+    const handleSelectedDayChange = (name: string, selectedDay: Date ) => {
       setSelectedDay(selectedDay) // update the selected day
       const formattedDate = format(selectedDay, 'MMM-dd-yyyy') // normalize the date
       setValue(name, formattedDate) // set the value of the input field
+      setShowCalendar("CalendarClosed") // Remove if don't want calendar to close after selecting a day
       if (onChange) { // if onChange prop is passed, call it
         onChange(formattedDate) 
       }
@@ -132,5 +133,3 @@ let firstDayStartingCol = [
 
 export default DatePick
 
-// Calendar based on this tutorial
-// https://www.youtube.com/watch?v=9ySmMd5Cjc0

--- a/pages/docs/date-pick-article.tsx
+++ b/pages/docs/date-pick-article.tsx
@@ -131,7 +131,7 @@ const DatePickerPage: FC = () => {
 
             <Field name="datePickField" control={control} defaultValue="Default">
               <DatePick
-               // name="datePickField"
+                name="datePickField"
                 label="datePickField"
                 startYearRange={1990}
                 endYearRange={2030}

--- a/pages/docs/date-pick-article.tsx
+++ b/pages/docs/date-pick-article.tsx
@@ -129,7 +129,7 @@ const DatePickerPage: FC = () => {
               Date Picker
             </Heading>
 
-            <Field name="datePickField" control={control} defaultValue="">
+            <Field name="datePickField" control={control} defaultValue="Default">
               <DatePick
                // name="datePickField"
                 label="datePickField"
@@ -140,7 +140,7 @@ const DatePickerPage: FC = () => {
 
             <Divider padding="large" />
             <PrintInputValueButton
-              inputID="datePickTest"
+              inputID="datePickField"
               getValues={getValues}
             />
 


### PR DESCRIPTION
Fixes Issue #21 

The DatePick and Calendar are now synced. Selecting a date via the Calendar will update the input field.

Did this by creating and passing an onChange handler to Calendar.

Still need to handle defaultValue so it will be set to the current day.