### PR TITLE
Bug Fix #74 - pdf not rendering

### DIFF
--- a/app/components/form/formControl/FormTest2.tsx
+++ b/app/components/form/formControl/FormTest2.tsx
@@ -9,7 +9,8 @@ import ModalAlert from "@ui/ModalAlert"
 import ModalViewDoc from "@ui/ModalViewDoc"
 import CardSection from "@ui/CardSection"
 import DynamicPDF from "@product2/DynamicPDF"
-import { PDFViewer } from "@react-pdf/renderer"
+//import { PDFViewer } from "@react-pdf/renderer"
+import dynamic from "next/dynamic"
 import { pdfStyles } from "@product2/_pdfHelpers/pdfStyles"
 
 export type FormProps = {
@@ -37,6 +38,12 @@ const FormTest2: FC<FormProps> = ({
 }) => {
   const methods = useForm({ resolver: zodResolver(zodSchema), defaultValues })
   const formHasErrors = Object.keys(methods.formState.errors).length > 0
+
+  // Dynamically import PDFViewer to fix build bug since Next uses SSR
+  const PDFViewer = dynamic(
+    () => import("@react-pdf/renderer").then((mod) => mod.PDFViewer),
+    { ssr: false }
+  )
 
   return (
     <FormProvider {...methods}>

--- a/app/product2/DynamicPDF.tsx
+++ b/app/product2/DynamicPDF.tsx
@@ -32,39 +32,39 @@ Font.register({
   family: "Inter",
   fonts: [
     {
-      src: "http://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyeMZhrib2Bg-4.ttf",
+      src: "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyeMZhrib2Bg-4.ttf",
       fontWeight: 100,
     },
     {
-      src: "http://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuDyfMZhrib2Bg-4.ttf",
+      src: "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuDyfMZhrib2Bg-4.ttf",
       fontWeight: 200,
     },
     {
-      src: "http://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuOKfMZhrib2Bg-4.ttf",
+      src: "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuOKfMZhrib2Bg-4.ttf",
       fontWeight: 300,
     },
     {
-      src: "http://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfMZhrib2Bg-4.ttf",
+      src: "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfMZhrib2Bg-4.ttf",
       fontWeight: 400,
     },
     {
-      src: "http://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuI6fMZhrib2Bg-4.ttf",
+      src: "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuI6fMZhrib2Bg-4.ttf",
       fontWeight: 500,
     },
     {
-      src: "http://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuGKYMZhrib2Bg-4.ttf",
+      src: "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuGKYMZhrib2Bg-4.ttf",
       fontWeight: 600,
     },
     {
-      src: "http://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuFuYMZhrib2Bg-4.ttf",
+      src: "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuFuYMZhrib2Bg-4.ttf",
       fontWeight: 700,
     },
     {
-      src: "http://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuDyYMZhrib2Bg-4.ttf",
+      src: "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuDyYMZhrib2Bg-4.ttf",
       fontWeight: 800,
     },
     {
-      src: "http://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuBWYMZhrib2Bg-4.ttf",
+      src: "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuBWYMZhrib2Bg-4.ttf",
       fontWeight: 900,
     },
   ],

--- a/app/product2/DynamicPDF.tsx
+++ b/app/product2/DynamicPDF.tsx
@@ -1,3 +1,4 @@
+"use client"
 import React, { FC } from "react"
 import {
   Page,

--- a/app/product2/_pdfHelpers/filterInvalidSections.ts
+++ b/app/product2/_pdfHelpers/filterInvalidSections.ts
@@ -1,3 +1,4 @@
+"use client"
 import {
   DocTemplateCommonType,
   FormDataType,

--- a/app/product2/_pdfHelpers/renderFooter.tsx
+++ b/app/product2/_pdfHelpers/renderFooter.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { Page, Text, View } from "@react-pdf/renderer"
 import { pdfStyles } from "./pdfStyles"
 

--- a/app/product2/_pdfHelpers/renderPDFElements.tsx
+++ b/app/product2/_pdfHelpers/renderPDFElements.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { Page, Text, View, Document, StyleSheet } from "@react-pdf/renderer"
 import { pdfStyles } from "./pdfStyles"
 import {

--- a/app/product2/_pdfHelpers/renderPDFTOC.tsx
+++ b/app/product2/_pdfHelpers/renderPDFTOC.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { Image, Text, Link, View } from "@react-pdf/renderer"
 import { pdfStyles } from "./pdfStyles"
 import { filterInvalidSections } from "./filterInvalidSections"

--- a/app/product2/_pdfHelpers/renderPDFTerms.tsx
+++ b/app/product2/_pdfHelpers/renderPDFTerms.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { renderPDFElements } from "./renderPDFElements"
 import {
   SelectedTemplateProps,

--- a/app/product2/_pdfHelpers/renderSigning.tsx
+++ b/app/product2/_pdfHelpers/renderSigning.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { View, Text, StyleSheet } from "@react-pdf/renderer"
 import { pdfStyles } from "./pdfStyles"
 import { FormDataType } from "../_schemas/productTypes"

--- a/app/product2/_schemas/createSchemaTemplateA.ts
+++ b/app/product2/_schemas/createSchemaTemplateA.ts
@@ -1,3 +1,4 @@
+"use client"
 import { supportedLocationGroups } from "./supportedLocations"
 import { FormDataType } from "./productTypes"
 import { FieldValues } from "react-hook-form"

--- a/app/product2/page.tsx
+++ b/app/product2/page.tsx
@@ -26,7 +26,7 @@ import DatePick from "@components/form/DatePick"
 
 import DynamicPDF from "./DynamicPDF"
 
-const Product3 = () => {
+const Product2 = () => {
   // Dynamically import PDFViewer to fix build bug since Next uses SSR
   const PDFViewer = dynamic(
     () => import("@react-pdf/renderer").then((mod) => mod.PDFViewer),
@@ -202,7 +202,6 @@ const Product3 = () => {
   )
 }
 
-export default Product3
+export default Product2
 
-// Need a useEffect for loading correct template. Want it to load dynamic values on first load based on location answer which should default based on estimated location.
 // Need a way to hide/show premium content based on license and auth state


### PR DESCRIPTION
BUG Fix for https://github.com/tayv/Project-Bubblegum/issues/74

Solution:
- Switched Google Font imports in `DynamicPDF` to use https instead of http

Notes:
- Appears to have been caused by Mixed Content Blocking since the app's being loaded over a secure HTTPS connection, but it was trying to make a request to an insecure HTTP URL.
- Also made the renderPDF helpers into client components since they have lots of conditional logic and make use of the react-pdf renderer library which could be resource intensive

Other Details:
`
 "Mixed Content: The page at '<URL>' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint '<URL>'. This request has been blocked; the content must be served over HTTPS."
`