### PR TITLE
Created custom hook for loadingpdf

### DIFF
--- a/app/components/form/PillBar.tsx
+++ b/app/components/form/PillBar.tsx
@@ -19,6 +19,7 @@ import dynamic from "next/dynamic"
 import ModalAlert from "@ui/ModalAlert"
 import { pdfStyles } from "@product2/_pdfHelpers/pdfStyles"
 import DynamicPDF from "@product2/DynamicPDF"
+import { useLoadPreviewPDF } from "@hooks/useLoadPreviewPDF"
 
 type PillBarProps = {
   methods: UseFormReturn // used so we can render preview of document in Toolbox for authenticated users
@@ -65,13 +66,8 @@ const ToolBox: FC<ToolBoxProps> = ({
     { ssr: false }
   )
 
-  // Use state so PDFViewer will rerender when new in-progress formData exists after button click
-  const [latestFormData, setlatestFormData] = useState(getValues())
-  // Pass this to ModalViewDoc so it will run onClick to open modal
-  const handlePreviewPDF = () => {
-    const updatedValue = getValues()
-    setlatestFormData(updatedValue)
-  }
+  // This hook gets use the latest form values based on when trigger button is clicked
+  const { handlePreviewPDF, latestFormData } = useLoadPreviewPDF()
 
   return (
     <>

--- a/app/components/form/formControl/Form.tsx
+++ b/app/components/form/formControl/Form.tsx
@@ -9,6 +9,7 @@ import ModalAlert from "@ui/ModalAlert"
 import ModalViewDoc from "@ui/ModalViewDoc"
 import Card from "@components/ui/Card"
 import DynamicPDF from "@product2/DynamicPDF"
+import { useLoadPreviewPDF } from "@hooks/useLoadPreviewPDF"
 //import { PDFViewer } from "@react-pdf/renderer"
 
 import dynamic from "next/dynamic"
@@ -48,6 +49,8 @@ const Form: FC<FormProps> = ({
 }) => {
   const methods = useForm({ resolver: zodResolver(zodSchema), defaultValues })
   const formHasErrors = Object.keys(methods.formState.errors).length > 0
+
+  const { handlePreviewPDF, latestFormData } = useLoadPreviewPDF({ methods })
 
   // Dynamically import PDFViewer to fix build bug since Next uses SSR. See: https://www.youtube.com/watch?v=HhLa-D0SXlI
   const PDFViewer = dynamic(
@@ -93,7 +96,9 @@ const Form: FC<FormProps> = ({
               triggerText="Preview Doc"
               title="Document Title"
               description="This is a description"
-              formData={methods.getValues()}
+              //formData={methods.getValues()}
+              formData={latestFormData}
+              handlePreviewPDF={handlePreviewPDF}
             >
               {/* Need to pass formData directly as prop instead of useFormContext() or passing all methods because PDFViewer creates a separate context */}
               <PDFViewer style={pdfStyles.pdfViewer}>

--- a/app/hooks/useLoadPreviewPDF.tsx
+++ b/app/hooks/useLoadPreviewPDF.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react"
+import { useFormContext, UseFormReturn } from "react-hook-form"
+
+type LoadPreviewPDFProps = {
+  methods?: UseFormReturn
+}
+
+export const useLoadPreviewPDF = ({ methods }: LoadPreviewPDFProps = {}) => {
+  // The method prop allows the hook to be used outside of Form since desktop version places Toolbox outside FormProvider
+
+  // Always call useFormContext to avoid breaking rule of no conditional hooks
+  const formContextMethods = useFormContext()
+  // If methods not passed, use useFormContext
+  const formMethods = methods || formContextMethods
+
+  if (!formMethods) {
+    throw new Error(
+      "useLoadPreviewPDF must be used within a FormProvider or methods must be passed as a prop."
+    )
+  }
+
+  // RHF's getValues used to grab the latest form data. Save it to state so that we can trigger re-renders if formData changes
+  const { getValues } = formMethods
+  const [latestFormData, setlatestFormData] = useState(getValues())
+
+  // This will be used by the button onClick to open the PDF preview modal
+  const handlePreviewPDF = () => {
+    const updatedValue = getValues()
+    setlatestFormData(updatedValue)
+  }
+
+  return { handlePreviewPDF, latestFormData }
+}
+
+// --- HOW TO USE ---
+
+// 1. If component wrapped by RHF's FormProvider:
+// const { handlePreviewPDF, latestFormData } = useLoadPreviewPDF()
+
+// 2. If component not wrapped by RHF's FormProvider but has access to methods from useForm (e.g. in Form)
+// const { handlePreviewPDF, latestFormData } = useLoadPreviewPDF({ methods })


### PR DESCRIPTION
- Moved logic into custom hook called useLoadPreviewPDF
- Allows the desktop version to also display latest form data (previously didn't work as outside FormProvider)