### PR TITLE
BUGFIX: Issue #62 hasError 

### DIFF
--- a/app/components/form/Checkbox.tsx
+++ b/app/components/form/Checkbox.tsx
@@ -15,13 +15,23 @@ export type CheckboxProps = {
   className?: string
   onChange?: any
   defaultChecked?: boolean
+  hasError?: boolean
 }
 
 const Checkbox: FC<CheckboxProps> = forwardRef<
   HTMLButtonElement,
   CheckboxProps
 >(function setRefCheckbox(
-  { children, name, type = "standard", onChange, value, id = name, ...props },
+  {
+    children,
+    name,
+    type = "standard",
+    onChange,
+    value,
+    id = name,
+    hasError = false,
+    ...props
+  },
   ref
 ) {
   return (

--- a/app/components/form/DatePick.tsx
+++ b/app/components/form/DatePick.tsx
@@ -14,6 +14,7 @@ export type DatePickProps = {
   value?: string | number
   tipText?: string | null
   defaultValue?: string | Date // should add a type guard function to validate format in future
+  hasError?: boolean
 }
 
 // Component ----------------------------------------------------------------------
@@ -29,6 +30,8 @@ const DatePick: FC<DatePickProps & Omit<CalendarProps, "name"> & InputProps> =
       startYearRange,
       endYearRange,
       defaultValue = format(startOfToday(), "MMM-dd-yyyy"), // Want the calendar to open to today's date by default unless a custom value is passed
+      hasError = false,
+      ...props
     },
     ref
   ) {

--- a/app/components/form/Select.tsx
+++ b/app/components/form/Select.tsx
@@ -16,6 +16,7 @@ export type GroupListItems = {
 export type SelectProps = {
   value?: string
   name?: string
+  hasError?: boolean
   placeholder: string
   itemOptions: Array<FlatListItems | GroupListItems>
   onChange?: (value: string) => void
@@ -79,7 +80,10 @@ const renderGroupedItems = (itemOptions: Array<GroupListItems>) => {
 
 // MAIN COMPONENT
 const Select: FC<SelectProps> = forwardRef<HTMLButtonElement, SelectProps>(
-  function setRefSelect({ placeholder, itemOptions, ...props }, ref) {
+  function setRefSelect(
+    { placeholder, itemOptions, hasError = false, ...props },
+    ref
+  ) {
     return (
       <SelectRadix.Root {...props} onValueChange={props.onChange}>
         <SelectRadix.Trigger

--- a/app/components/form/formControl/Field.tsx
+++ b/app/components/form/formControl/Field.tsx
@@ -97,6 +97,7 @@ Field.Control = function FieldControl({ children }: FieldControlProps) {
         return (
           <>
             {/* Unable to pass custom type to Slot so type assertion used on field to supress hasError TS error */}
+            {/* Make sure to destructure hasError in any child components to prevent react dom hasError. See: https://github.com/tayv/Project-Bubblegum/issues/62 */}
             <Slot {...(field as any)} onBlur={handleOnBlur} hasError={hasError}>
               {children}
             </Slot>


### PR DESCRIPTION
- Updated all form input components to destructure hasError prop. 
- Necessary since Radix UI's Slot component used in Field component is designed to forward all props to the underlying DOM element.